### PR TITLE
Additional third party paper implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ This is a curated list of tutorials, projects, libraries, videos, papers, books 
 - [PyTorch GAN Collection](https://github.com/znxlwm/pytorch-generative-model-collections)
 - [Compact Bilinear Pooling](https://github.com/DeepInsight-PCALab/CompactBilinearPooling-Pytorch)
 - [Striving for Simplicity: The All Convolutional Net](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
-- [Deep Inside Convolutional Networks: Visualisng Image Classification Models and Saliency Maps](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
+- [Deep Inside Convolutional Networks: Visualising Image Classification Models and Saliency Maps](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
 - [Deep Neural Networks are Easily Fooled: High Confidence Predictions for Unrecognizable Images](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
  - [Grad-CAM: Visual Explanations from Deep Networks via Gradient-based Localization - 2](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
 

--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ This is a curated list of tutorials, projects, libraries, videos, papers, books 
 - [PyTorch GAN Collection](https://github.com/znxlwm/pytorch-generative-model-collections)
 - [Compact Bilinear Pooling](https://github.com/DeepInsight-PCALab/CompactBilinearPooling-Pytorch)
 - [Striving for Simplicity: The All Convolutional Net](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
-- [Learning Deep Features for Discriminative Localization](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
-
-
+- [Deep Inside Convolutional Networks: Visualisng Image Classification Models and Saliency Maps](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
+- [Deep Neural Networks are Easily Fooled: High Confidence Predictions for Unrecognizable Images](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
+ - [Grad-CAM: Visual Explanations from Deep Networks via Gradient-based Localization - 2](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
 
 ## Projects Implemented with Pytorch
 - [Collection of Sequence to Sequence Models with PyTorch](https://github.com/MaximumEntropy/Seq2Seq-PyTorch)

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ This is a curated list of tutorials, projects, libraries, videos, papers, books 
 - [Attentive Recurrent Comparators](https://github.com/sanyam5/arc-pytorch)
 - [PyTorch GAN Collection](https://github.com/znxlwm/pytorch-generative-model-collections)
 - [Compact Bilinear Pooling](https://github.com/DeepInsight-PCALab/CompactBilinearPooling-Pytorch)
+- [Striving for Simplicity: The All Convolutional Net](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
+
 
 ## Projects Implemented with Pytorch
 - [Collection of Sequence to Sequence Models with PyTorch](https://github.com/MaximumEntropy/Seq2Seq-PyTorch)

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ This is a curated list of tutorials, projects, libraries, videos, papers, books 
 - [PyTorch GAN Collection](https://github.com/znxlwm/pytorch-generative-model-collections)
 - [Compact Bilinear Pooling](https://github.com/DeepInsight-PCALab/CompactBilinearPooling-Pytorch)
 - [Striving for Simplicity: The All Convolutional Net](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
+- [Learning Deep Features for Discriminative Localization](https://github.com/utkuozbulak/pytorch-cnn-visualizations)
+
 
 
 ## Projects Implemented with Pytorch


### PR DESCRIPTION
Added the implementations for the papers listed below at the following repository.

Repository link: https://github.com/utkuozbulak/pytorch-cnn-visualizations

Papers:
1- Striving for Simplicity: The All Convolutional Net
2- Deep Inside Convolutional Networks: Visualising Image Classification Models and Saliency Maps
3- Deep Neural Networks are Easily Fooled: High Confidence Predictions for Unrecognizable Images
4- Grad-CAM: Visual Explanations from Deep Networks via Gradient-based Localization

A Grad-CAM implementation existed already so I added the name as *original_paper_name* - 2
If that's a problem I can remove/update accordingly.
