### PR TITLE
Return the Catalyst framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ This is a curated list of tutorials, projects, libraries, videos, papers, books 
 - [torchbearer: A model fitting library for PyTorch](https://github.com/ecs-vlc/torchbearer)
 - [PyTorch to Keras model converter](https://github.com/nerox8664/pytorch2keras)
 - [Gluon to PyTorch model converter with code generation](https://github.com/nerox8664/gluon2pytorch)
+- [Catalyst: High-level utils for PyTorch DL & RL research](https://github.com/catalyst-team/catalyst)
 
 ## PyTorch Video Tutorials
 - [Practical Deep Learning with PyTorch](https://www.udemy.com/practical-deep-learning-with-pytorch/?couponCode=DEEPWIZARD)


### PR DESCRIPTION
Catalyst was accidentally removed in [this commit](https://github.com/ritchieng/the-incredible-pytorch/commit/bdc6e2153a5a3d09f6070e31249b6bb4793c765f#diff-04c6e90faac2675aa89e2176d2eec7d8L416) so I return it.

As I previously noticed at #85 : 

[Catalyst](https://github.com/catalyst-team/catalyst) – High-level utils for PyTorch DL & RL research.
It was developed with a focus on reproducibility, fast experimentation and code/ideas reusing. Being able to research/develop something new, rather than write another regular train loop.

Catalyst is used in [Kaggle](https://github.com/Kaggle/docker-python/pull/616), [Weights & Biases](https://docs.wandb.com/library/integrations/catalyst) and [ml-workspace](https://github.com/ml-tooling/ml-workspace/blob/develop/resources/libraries/requirements-full.txt#L65).

**Features**
  - Universal train/inference loop.
  - Configuration files for model/data hyperparameters.
  - Reproducibility – all source code and environment variables will be saved.
  - Callbacks – reusable train/inference pipeline parts.
  - Training stages support.
  - Easy customization.
  - PyTorch best practices (SWA, AdamW, OneCycle, Ranger optimizer, FP16 and more).