### PR TITLE
add kornia vision library

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ This is a curated list of tutorials, projects, libraries, videos, papers, books 
 - [TorchSharp, .NET API with access to underlying library powering PyTorch](https://github.com/interesaaat/TorchSharp)
 
 ## PyTorch Utilities
+- [Kornia: an Open Source Differentiable Computer Vision Library for PyTorch](https://kornia.org/)
 - [BackPACK to easily Extract Variance, Diagonal of Gauss-Newton, and KFAC](https://f-dangel.github.io/backpack/)
 - [Hessian in PyTorch](https://github.com/mariogeiger/hessian)
 - [Differentiable Convex Layers](https://github.com/cvxgrp/cvxpylayers)


### PR DESCRIPTION
this PR adds kornia to utilities section. However, I really miss a section for image pre-processing since there are quite a few libraries in that purpose: torchvision, albumentation, dali, etc. Missing also high level section for training frameworks like skorch, lightning, or ignite. Good recap though ! 