### PR TITLE
Add QQA4CO under Quantum Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ This is a curated list of tutorials, projects, libraries, videos, papers, books 
 ## <a name='QuantumMachineLearning'></a>Quantum Machine Learning
 - [Tor10, generic tensor-network library for quantum simulation in PyTorch](https://github.com/kaihsin/Tor10)
 - [PennyLane, cross-platform Python library for quantum machine learning with PyTorch interface](https://github.com/XanaduAI/pennylane)
+- [QQA4CO, GPU-parallel Quasi-Quantum Annealing for combinatorial optimisation in PyTorch (ICLR 2025)](https://github.com/Yuma-Ichikawa/QQA4CO)
 
 ## <a name='NeuralNetworkCompression'></a>Neural Network Compression
 - [Bayesian Compression for Deep Learning](https://github.com/KarenUllrich/Tutorial_BayesianCompressionForDL)


### PR DESCRIPTION
Adds **QQA4CO** to the `## Quantum Machine Learning` section, complementing the two existing entries (Tor10, PennyLane) with a *quantum-inspired classical solver* — i.e. the niche of running quantum-style optimisation on plain GPUs rather than circuit simulation.

QQA4CO implements **Parallel Quasi-Quantum Annealing (PQQA)** (Ichikawa & Arai, ICLR 2025), a gradient-based, batched solver for QUBO / Ising / spin-glass instances that runs entirely in PyTorch.

- Paper: https://openreview.net/forum?id=9EfBeXaXf0 (ICLR 2025, poster) · arXiv:[2409.02135](https://arxiv.org/abs/2409.02135)
- Code: https://github.com/Yuma-Ichikawa/QQA4CO · `pip install qqa` · BSD-3-Clause-Clear · DOI: [10.5281/zenodo.19648231](https://doi.org/10.5281/zenodo.19648231)

Format matches the existing two entries: `[Name, short description](URL)`.