### PR TITLE
Add llm.c by Andrej Karpathy to General NLP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ This is a curated list of tutorials, projects, libraries, videos, papers, books 
 
 ## <a name='GeneralNLP'></a>General NLP
 - [nanoGPT, fastest repository for training/finetuning medium-sized GPTs](https://github.com/karpathy/nanoGPT)
+- [llm.c, LLM training in simple, pure C/CUDA — GPT-2 in ~1000 lines of code with no PyTorch dependency](https://github.com/karpathy/llm.c)
 - [minGPT, Re-implementation of GPT to be small, clean, interpretable and educational](https://github.com/karpathy/minGPT)
 - [Espresso, Module Neural Automatic Speech Recognition Toolkit](https://github.com/freewym/espresso)
 - [Label-aware Document Representation via Hybrid Attention for Extreme Multi-Label Text Classification](https://github.com/HX-idiot/Hybrid_Attention_XML)


### PR DESCRIPTION
## Description

This PR adds **[llm.c](https://github.com/karpathy/llm.c)** by Andrej Karpathy to the General NLP section, alongside the existing nanoGPT and minGPT entries.

## Why this resource is valuable

`llm.c` is a natural complement to the nanoGPT and minGPT entries already in this section:

- **Pure C/CUDA**: Trains GPT-2 in approximately 1,000 lines of C/CUDA with no PyTorch or Python required — the ultimate low-level LLM reference
- **Educational**: Strips away all abstraction layers to show exactly how forward passes, backpropagation, and gradient updates work at the hardware level
- **Karpathy's trilogy**: nanoGPT → minGPT → llm.c forms a natural progression from high-level PyTorch to bare-metal C, and all three are by the same author
- **Performance**: Achieves GPT-2 (124M) training speed competitive with PyTorch via hand-tuned CUDA kernels
- **4k+ GitHub stars** and widely referenced in ML courses and blog posts as a deep-dive resource

This fills an obvious gap next to the already-listed nanoGPT and minGPT, completing Karpathy's set of minimal LLM implementations in this list.