### PR TITLE
Add Financial Machine Learning section and ml-quant-trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This is a curated list of tutorials, projects, libraries, videos, papers, books 
   - [Anomaly Detection](#anomaly-detection)
   - [Regression Types](#regression-types)
   - [Time Series](#time-series)
+  - [Financial Machine Learning](#financial-machine-learning)
   - [Synthetic Datasets](#synthetic-datasets)
   - [Neural Network General Improvements](#neural-network-general-improvements)
   - [DNN Applications in Chemistry and Physics](#dnn-applications-in-chemistry-and-physics)
@@ -679,6 +680,9 @@ This is a curated list of tutorials, projects, libraries, videos, papers, books 
 - [Variational Recurrent Autoencoder for Timeseries Clustering](https://github.com/tejaslodaya/timeseries-clustering-vae)
 - [Spatio-Temporal Neural Networks for Space-Time Series Modeling and Relations Discovery](https://github.com/edouardelasalles/stnn)
 - [Flow Forecast: A deep learning for time series forecasting framework built in PyTorch](https://github.com/AIStream-Peelout/flow-forecast)
+
+## <a name='FinancialMachineLearning'></a>Financial Machine Learning
+- [ml-quant-trading, PyTorch research stack for multi-factor trading with 213 factors, bias correction, portfolio optimization, and vectorized backtesting](https://github.com/initial-d/ml-quant-trading)
 
 ## <a name='SyntheticDatasets'></a>Synthetic Datasets
 - [Meta-Sim: Learning to Generate Synthetic Datasets](https://github.com/nv-tlabs/meta-sim)


### PR DESCRIPTION
## What

Adds a small Financial Machine Learning section and lists `ml-quant-trading`, an MIT-licensed PyTorch research stack accompanying [Machine Learning Enhanced Multi-Factor Quantitative Trading](https://arxiv.org/abs/2507.07107).

## Why it fits

The repository uses PyTorch for mask-aware factor computation and ML models. It includes 213 factors, bias correction, portfolio optimization, and vectorized backtesting. Since the list did not have a finance-specific category, the change adds one adjacent to Time Series instead of placing the project in a less accurate section.

## Impact

Adds one table-of-contents link, one section heading, and one project entry. Existing entries are unchanged.

## Validation

- Confirmed the project link returns HTTP 200
- Checked that the project is not already listed
- Verified the table-of-contents anchor and existing bullet format
- Ran `git diff --check`

## Disclosure

I maintain the submitted repository and am an author of the linked paper. This is a transparent self-submission for maintainer review.